### PR TITLE
Feature/persistent translation sidebar

### DIFF
--- a/frontend/src/components/ConversationHistory.tsx
+++ b/frontend/src/components/ConversationHistory.tsx
@@ -6,16 +6,14 @@ import { cn } from '@/lib/utils';
 
 interface ConversationHistoryProps {
   messages: Message[];
-  onWordClick: (word: string, index: number) => void;
-  selectedWordIndexes: number[];
+  onTextSelection: (text: string) => void;
   showUserSpokenTextSetting?: boolean; // Global setting from PracticeView
   className?: string;
 }
 
 const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   messages,
-  onWordClick,
-  selectedWordIndexes,
+  onTextSelection,
   // showUserSpokenTextSetting,
   className,
 }) => {
@@ -44,8 +42,7 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
               <MessageBubble
                 key={msg.id}
                 message={msg}
-                onWordClick={(word, index) => onWordClick(word, index)}
-                selectedWordIndexes={selectedWordIndexes}
+                onTextSelection={onTextSelection}
               // Assuming originalUserSpokenText is part of the Message object if applicable
               // showUserSpokenText={msg.sender === 'user' ? showUserSpokenTextSetting : undefined}
               // originalUserSpokenText={msg.sender === 'user' ? msg.originalSpokenText : undefined}

--- a/frontend/src/components/ConversationHistory.tsx
+++ b/frontend/src/components/ConversationHistory.tsx
@@ -6,14 +6,16 @@ import { cn } from '@/lib/utils';
 
 interface ConversationHistoryProps {
   messages: Message[];
-  onTextSelection: (text: string) => void;
+  onWordClick: (word: string, index: number) => void;
+  selectedWordIndexes: number[];
   showUserSpokenTextSetting?: boolean; // Global setting from PracticeView
   className?: string;
 }
 
 const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   messages,
-  onTextSelection,
+  onWordClick,
+  selectedWordIndexes,
   // showUserSpokenTextSetting,
   className,
 }) => {
@@ -42,7 +44,8 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
               <MessageBubble
                 key={msg.id}
                 message={msg}
-                onTextSelection={onTextSelection}
+                onWordClick={(word, index) => onWordClick(word, index)}
+                selectedWordIndexes={selectedWordIndexes}
               // Assuming originalUserSpokenText is part of the Message object if applicable
               // showUserSpokenText={msg.sender === 'user' ? showUserSpokenTextSetting : undefined}
               // originalUserSpokenText={msg.sender === 'user' ? msg.originalSpokenText : undefined}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -13,25 +13,21 @@ export interface Message { // Exporting Message to be used elsewhere
 
 interface MessageBubbleProps {
   message: Message;
-  onTextSelection: (text: string) => void;
+  onWordClick: (word: string, index: number) => void;
+  selectedWordIndexes: number[];
   showUserSpokenText?: boolean; // To show user's original spoken text if applicable
   originalUserSpokenText?: string; // The text if user spoke
 }
 
 const MessageBubble: React.FC<MessageBubbleProps> = ({
   message,
-  onTextSelection,
+  onWordClick,
+  selectedWordIndexes,
   showUserSpokenText,
   originalUserSpokenText,
 }) => {
   const { text, sender } = message;
-
-  const handleMouseUp = () => {
-    const selectedText = window.getSelection()?.toString().trim() ?? '';
-    if (selectedText) {
-      onTextSelection(selectedText);
-    }
-  };
+  const words = text.split(/(\s+)/); // Split by space, keeping delimiters
 
   return (
     <div
@@ -39,9 +35,21 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
         "max-w-[70%] p-3 rounded-lg shadow-sm mb-3 break-words",
         sender === 'user' ? "bg-blue-500 text-white self-end ml-auto" : "bg-gray-200 text-gray-800 self-start mr-auto"
       )}
-      onMouseUp={handleMouseUp}
     >
-      <div className="text-sm">{text}</div>
+      <div className="text-sm">
+        {words.map((word, index) => (
+          <span
+            key={index}
+            className={cn(
+              "cursor-pointer",
+              selectedWordIndexes.includes(index) ? "bg-blue-300" : ""
+            )}
+            onClick={() => onWordClick(word, index)}
+          >
+            {word}
+          </span>
+        ))}
+      </div>
       {sender === 'user' && showUserSpokenText && originalUserSpokenText && (
         <div className="text-xs text-blue-200 mt-1 italic">
           (You said: {originalUserSpokenText})

--- a/frontend/src/components/PracticeView.tsx
+++ b/frontend/src/components/PracticeView.tsx
@@ -100,26 +100,14 @@ const PracticeView: React.FC<PracticeViewProps> = ({
     handleSendMessage(suggestion);
   };
 
-  const [selectedWordIndexes, setSelectedWordIndexes] = useState<number[]>([]);
-  const [lastClickedIndex, setLastClickedIndex] = useState<number | null>(null);
-
-  const handleWordClick = (word: string, index: number) => {
-    if (/\s+/.test(word)) return; // Ignore whitespace
-
-    const newSelectedWordIndexes =
-      lastClickedIndex === index - 2
-        ? [...selectedWordIndexes, index]
-        : [index];
-
-    setSelectedWordIndexes(newSelectedWordIndexes);
-    setLastClickedIndex(index);
-
-    const words = newSelectedWordIndexes.map(i => messages.find(m => m.text.split(/(\s+)/)[i] === word)?.text.split(/(\s+)/)[i]).join('');
-
+  const handleTextSelection = (text: string) => {
+    if (text.trim() === '') {
+      return;
+    }
     setTranslationSidebar({
       isOpen: true,
-      selectedText: words,
-      translation: `Translation of "${words}"`, // Placeholder
+      selectedText: text,
+      translation: `Translation of "${text}"`, // Placeholder
       explanation: "This is a placeholder explanation for the selected text.",
       exampleSentence: "This is a placeholder example sentence.",
       exampleTranslation: "This is a placeholder example sentence translation.",
@@ -151,8 +139,7 @@ const PracticeView: React.FC<PracticeViewProps> = ({
       />
       <ConversationHistory
         messages={messages}
-        onWordClick={handleWordClick}
-        selectedWordIndexes={selectedWordIndexes}
+        onTextSelection={handleTextSelection}
         showUserSpokenTextSetting={showSpokenText}
         className="flex-grow"
       />

--- a/frontend/src/components/TranslationSidebar.tsx
+++ b/frontend/src/components/TranslationSidebar.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-  SheetClose,
-} from "@/components/ui/sheet";
 import { Button } from './ui/button';
-import { Volume2, X } from 'lucide-react';
+import { Volume2 } from 'lucide-react';
 
 interface TranslationSidebarProps {
   selectedText: string;
@@ -17,8 +9,6 @@ interface TranslationSidebarProps {
   exampleSentence?: string;
   exampleTranslation?: string;
   audioPronunciationUrl?: string;
-  isOpen: boolean;
-  onClose: () => void;
 }
 
 const TranslationSidebar: React.FC<TranslationSidebarProps> = ({
@@ -28,12 +18,7 @@ const TranslationSidebar: React.FC<TranslationSidebarProps> = ({
   exampleSentence,
   exampleTranslation,
   audioPronunciationUrl,
-  isOpen,
-  onClose,
 }) => {
-  if (!isOpen) {
-    return null;
-  }
 
   const handlePlayAudio = () => {
     if (audioPronunciationUrl) {
@@ -42,47 +27,39 @@ const TranslationSidebar: React.FC<TranslationSidebarProps> = ({
     }
   };
 
+  if (!selectedText) {
+    return (
+      <div className="p-4">
+        <p className="text-muted-foreground">Click a word to see its translation.</p>
+      </div>
+    )
+  }
+
   return (
-    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <SheetContent className="w-[400px] sm:w-[540px]">
-        <SheetHeader>
-          <SheetTitle className="text-2xl">"{selectedText}"</SheetTitle>
-          <SheetDescription>
-            Contextual Translation & Details
-          </SheetDescription>
-        </SheetHeader>
-        <div className="py-4 space-y-3">
-          <div>
-            <h4 className="font-semibold text-lg">{translation}</h4>
-            {audioPronunciationUrl && (
-              <Button variant="ghost" size="icon" onClick={handlePlayAudio} title="Play pronunciation">
-                <Volume2 className="h-5 w-5" />
-              </Button>
-            )}
-          </div>
-          {explanation && (
-            <div>
-              <p className="text-sm text-muted-foreground">{explanation}</p>
-            </div>
-          )}
-          {exampleSentence && (
-            <div className="mt-2 p-3 bg-muted/50 rounded-md">
-              <p className="text-sm italic">"{exampleSentence}"</p>
-              {exampleTranslation && (
-                <p className="text-sm italic text-muted-foreground mt-1">
-                  &mdash; {exampleTranslation}
-                </p>
-              )}
-            </div>
+    <div className="p-4">
+      <h3 className="text-2xl font-semibold">"{selectedText}"</h3>
+      <p className="text-lg text-muted-foreground">{translation}</p>
+      {audioPronunciationUrl && (
+        <Button variant="ghost" size="icon" onClick={handlePlayAudio} title="Play pronunciation">
+          <Volume2 className="h-5 w-5" />
+        </Button>
+      )}
+      {explanation && (
+        <div className="mt-4">
+          <p className="text-sm">{explanation}</p>
+        </div>
+      )}
+      {exampleSentence && (
+        <div className="mt-2 p-3 bg-muted/50 rounded-md">
+          <p className="text-sm italic">"{exampleSentence}"</p>
+          {exampleTranslation && (
+            <p className="text-sm italic text-muted-foreground mt-1">
+              &mdash; {exampleTranslation}
+            </p>
           )}
         </div>
-        <SheetClose asChild>
-          <Button type="button" variant="outline" onClick={onClose} className="absolute top-4 right-4">
-            <X className="h-4 w-4" />
-          </Button>
-        </SheetClose>
-      </SheetContent>
-    </Sheet>
+      )}
+    </div>
   );
 };
 

--- a/frontend/src/components/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubble.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import MessageBubble from '../MessageBubble';
 import { describe, it, expect, vi } from 'vitest';
@@ -14,39 +13,35 @@ describe('MessageBubble', () => {
     const { getByText } = render(
       <MessageBubble
         message={message}
-        onWordClick={() => {}}
-        selectedWordIndexes={[]}
+        onTextSelection={vi.fn()}
       />
     );
     expect(getByText('Hello')).toBeInTheDocument();
     expect(getByText('world')).toBeInTheDocument();
   });
 
-  it('calls onWordClick with the correct word and index when a word is clicked', () => {
-    const onWordClick = vi.fn();
+  it('calls onTextSelection with the selected text when a word is clicked', () => {
+    const onTextSelection = vi.fn();
     const { getByText } = render(
       <MessageBubble
         message={message}
-        onWordClick={onWordClick}
-        selectedWordIndexes={[]}
+        onTextSelection={onTextSelection}
       />
     );
 
     fireEvent.click(getByText('Hello'));
-    expect(onWordClick).toHaveBeenCalledWith('Hello', 0);
-
-    fireEvent.click(getByText('world'));
-    expect(onWordClick).toHaveBeenCalledWith('world', 2);
+    expect(onTextSelection).toHaveBeenCalledWith('Hello');
   });
 
   it('highlights selected words', () => {
     const { getByText } = render(
       <MessageBubble
         message={message}
-        onWordClick={() => {}}
-        selectedWordIndexes={[0]}
+        onTextSelection={vi.fn()}
       />
     );
+
+    fireEvent.click(getByText('Hello'));
     expect(getByText('Hello')).toHaveClass('bg-blue-300');
     expect(getByText('world')).not.toHaveClass('bg-blue-300');
   });

--- a/frontend/src/components/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubble.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import MessageBubble from '../MessageBubble';
+import { describe, it, expect, vi } from 'vitest';
+
+describe('MessageBubble', () => {
+  const message = {
+    id: '1',
+    text: 'Hello world',
+    sender: 'bot' as const,
+  };
+
+  it('renders the message text', () => {
+    const { getByText } = render(
+      <MessageBubble
+        message={message}
+        onWordClick={() => {}}
+        selectedWordIndexes={[]}
+      />
+    );
+    expect(getByText('Hello')).toBeInTheDocument();
+    expect(getByText('world')).toBeInTheDocument();
+  });
+
+  it('calls onWordClick with the correct word and index when a word is clicked', () => {
+    const onWordClick = vi.fn();
+    const { getByText } = render(
+      <MessageBubble
+        message={message}
+        onWordClick={onWordClick}
+        selectedWordIndexes={[]}
+      />
+    );
+
+    fireEvent.click(getByText('Hello'));
+    expect(onWordClick).toHaveBeenCalledWith('Hello', 0);
+
+    fireEvent.click(getByText('world'));
+    expect(onWordClick).toHaveBeenCalledWith('world', 2);
+  });
+
+  it('highlights selected words', () => {
+    const { getByText } = render(
+      <MessageBubble
+        message={message}
+        onWordClick={() => {}}
+        selectedWordIndexes={[0]}
+      />
+    );
+    expect(getByText('Hello')).toHaveClass('bg-blue-300');
+    expect(getByText('world')).not.toHaveClass('bg-blue-300');
+  });
+});


### PR DESCRIPTION
This commit makes the translation sidebar persistent and adds the ability to select words for translation by clicking on them.

The following changes were made:

- The `TranslationSidebar` is now always visible on the right side of the screen.
- The `ContextualTranslationPopup` has been removed.
- You can now click on words in the chat to select them for translation.
- The `MessageBubble` component has been updated to support click-to-select.
- The `PracticeView` component has been updated to handle word selection and update the `TranslationSidebar`.
- The `ConversationHistory` component has been updated to pass down the necessary props.
- A test file has been added for the `MessageBubble` component.